### PR TITLE
🚧 test: Trying to drop TravisCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,7 @@ jobs:
           command: |
             ls -halt
             ls -halt ./coverage
-            ./node_modules/.bin/jest --coverage --coverageReporters=text-lcov | coveralls
-            ./node_modules/.bin/jest --coverage --coverageReporters=text-lcov | codecov
-            # 'cat ./coverage/lcov.info | coveralls'
+            cat ./coverage/lcov.info | coveralls
             # 'cat ./coverage/lcov.info | codecov'
       - save_cache:
           key: v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-lock-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           command: |
             ls -halt
             ls -halt ./coverage
-            jest --coverage --coverageReporters=text-lcov | coveralls
-            jest --coverage --coverageReporters=text-lcov | codecov
+            ./node_modules/.bin/jest --coverage --coverageReporters=text-lcov | coveralls
+            ./node_modules/.bin/jest --coverage --coverageReporters=text-lcov | codecov
             # 'cat ./coverage/lcov.info | coveralls'
             # 'cat ./coverage/lcov.info | codecov'
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           when: on_success
           command: |
             ls -halt
+            ls -halt ./coverage
             # 'cat ./coverage/lcov.info | coveralls'
             # 'cat ./coverage/lcov.info | codecov'
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,20 @@ jobs:
             - v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-cache-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}
             - v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-cache-master-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: Install latest NPM
-          command: npm i -g npm@latest --quiet
+          name: Install Latest NPM
+          command: npm i -g npm@latest codecov coveralls --quiet
       - run:
-          name: Install dependencies
+          name: Install Dependencies
           command: npm i --quiet
       - run:
-          name: Run tests
+          name: Run Tests
           command: npm t
+      - run:
+          name: Test Success
+          when: on_success
+          command: |
+            'cat ./coverage/lcov.info | coveralls'
+            'cat ./coverage/lcov.info | codecov'
       - save_cache:
           key: v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-lock-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
           command: |
             ls -halt
             ls -halt ./coverage
+            jest --coverage --coverageReporters=text-lcov | coveralls
+            jest --coverage --coverageReporters=text-lcov | codecov
             # 'cat ./coverage/lcov.info | coveralls'
             # 'cat ./coverage/lcov.info | codecov'
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,8 @@ jobs:
           name: Test Success
           when: on_success
           command: |
-            ls -halt
-            ls -halt ./coverage
             cat ./coverage/lcov.info | coveralls
-            # 'cat ./coverage/lcov.info | codecov'
+            cat ./coverage/lcov.info | codecov
       - save_cache:
           key: v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-lock-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,9 @@ jobs:
           name: Test Success
           when: on_success
           command: |
-            'cat ./coverage/lcov.info | coveralls'
-            'cat ./coverage/lcov.info | codecov'
+            ls -halt
+            # 'cat ./coverage/lcov.info | coveralls'
+            # 'cat ./coverage/lcov.info | codecov'
       - save_cache:
           key: v{{ .Environment.CIRCLE_BUILD_NUM }}-npm-lock-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:


### PR DESCRIPTION
## Description

CircleCI has been so popular with its containerized approach which is faster than that of TravisCI's VM approach by a few magnitude.

## Notable changes

- [ ] To drop TraviCI in favor of CircleCI (totally!)